### PR TITLE
PlayerDataをMonoBehaviourを使わない仕様に変更した、Prefabsフォルダを追加

### DIFF
--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f056e1723cfe014478ba26cbbf189316
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Managers.prefab
+++ b/Assets/Prefabs/Managers.prefab
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1672740091630904164
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1672740091630904160}
+  m_Layer: 0
+  m_Name: Managers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1672740091630904160
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1672740091630904164}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Managers.prefab.meta
+++ b/Assets/Prefabs/Managers.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aa503e6aa8c75084da9c5f47ffa8dc0c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -123,37 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &135181185
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 135181189}
-  m_Layer: 0
-  m_Name: Managers
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &135181189
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 135181185}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &508670100
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/PlayerData.cs
+++ b/Assets/Scripts/Player/PlayerData.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
 
 /// <summary>
 /// プレイヤーのデータを持つクラス
 /// </summary>
-public class PlayerData : MonoBehaviour, IHandCollection, ILifeChange
+public class PlayerData : IHandCollection, ILifeChange
 {
     #region public property
 
@@ -17,7 +16,7 @@ public class PlayerData : MonoBehaviour, IHandCollection, ILifeChange
     /// <summary>
     /// プレイヤーのシールドの読み取り専用プロパティ
     /// </summary>
-    public int Shild => _shield;
+    public int Shield => _shield;
 
     /// <summary>
     /// プレイヤーの手札の読み取り専用プロパティ
@@ -67,9 +66,9 @@ public class PlayerData : MonoBehaviour, IHandCollection, ILifeChange
 
     #endregion
 
-    #region unity event
+    #region constructor
 
-    private void Start()
+    public PlayerData()
     {
         Init();
     }


### PR DESCRIPTION
## PR で修正される機能
* PlayerDataをMonoBehaviourを使わずに実装
* 他のタスクで使用する際にコンフリクトの可能性があったので先にフォルダを追加した
> Prefabsフォルダがない状態でPrefabsフォルダに保存するようIssueに書いてあったため、複数の作業者が同じ名前のフォルダを作成する恐れがあった